### PR TITLE
Increasing js-schema dependency version to avoid undef error during package require

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git@github.com:molnarg/generate.js.git"
   },
   "dependencies": {
-    "js-schema" : "0.6.1",
+    "js-schema" : "0.6.2",
     "randexp" : "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!  I'm new to node.js, so forgive me if I'm just missing something obvious ...
I had to increment the js-schema version number to get the generate package to work for me.  Before the change I was seeing this:

```
> require('generate')
TypeError: Cannot read property 'patterns' of undefined
    at Object.<anonymous> (/Users/phil/generate.js/generate.js/lib/pattern/reference.js:1:105)
```
